### PR TITLE
Fix missing header in certificate generator

### DIFF
--- a/src/certgen_key_config.cc
+++ b/src/certgen_key_config.cc
@@ -28,6 +28,8 @@
 
 #include "certgen_key_config.h"
 
+#include <functional>
+
 //  Structure of our class
 namespace certgen
 {


### PR DESCRIPTION
<functional> header was missing in the certgen_key_config.cc, causing last build on Debian 10 to fail, as reported by @jimklimov.

It should be ok to add the dependency in the .cc file, as the std::function is used only within the file