### PR TITLE
Make SecW-socket path configurable

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,86 @@
+# Customized (manually maintained) bits of configure.ac for fty-warranty
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK])
+
+    AC_ARG_WITH([socketSecurityWallet],
+        [AS_HELP_STRING([--with-socketSecurityWallet=PATH], [Filename of fty-security-wallet service Unix socket])],,
+        [with_socketSecurityWallet=/run/fty-security-wallet/secw.socket])
+    AC_SUBST([socketSecurityWallet], [$with_socketSecurityWallet])
+    AC_SUBST([socketSecurityWalletDir], [`dirname $with_socketSecurityWallet`])
+
+])
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [
+    # Note: DO NOT refer to complete token name of this routine in the
+    # message below, or you would get an infinite loop in m4 autoconf ;)
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK_CONFIGVARS])
+
+    ### Customization follows, to avoid verbatim '${prefix}' in generated files:
+    dnl expand ${sysconfdir} and write it out
+    conftemp="${sysconfdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    CONFPATH=${conftemp}
+    AC_DEFINE_UNQUOTED(CONFPATH, "${conftemp}", [Default path for configuration files])
+    AC_SUBST(CONFPATH)
+
+    dnl same for datadir
+    conftemp="${datadir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    DATADIR=${conftemp}
+    AC_DEFINE_UNQUOTED(DATADIR, "${conftemp}", [Default path for data files])
+    AC_SUBST(DATADIR)
+
+    dnl same for bindir
+    conftemp="${bindir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    BINDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(BINDIR, "${conftemp}", [Default path for user executables])
+    AC_SUBST(BINDIR)
+
+    dnl same for sbindir
+    conftemp="${sbindir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    SBINDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(SBINDIR, "${conftemp}", [Default path for system executables])
+    AC_SUBST(SBINDIR)
+
+    dnl same for libdir
+    conftemp="${libdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    LIBDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(LIBDIR, "${conftemp}", [Default path for system libraries])
+    AC_SUBST(LIBDIR)
+
+    dnl same for libexecdir
+    conftemp="${libexecdir}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    LIBEXECDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(LIBEXECDIR, "${conftemp}", [Default path for system libraries - executable helpers])
+    AC_SUBST(LIBEXECDIR)
+
+    dnl same for prefix
+    conftemp="${prefix}"
+    eval conftemp=\"${conftemp}\"
+    eval conftemp=\"${conftemp}\"
+    PREFIXDIR=${conftemp}
+    AC_DEFINE_UNQUOTED(PREFIXDIR, "${conftemp}", [Default root path for component])
+    AC_SUBST(PREFIXDIR)
+
+    eval socketSecurityWallet=$socketSecurityWallet
+    eval socketSecurityWalletDir=$socketSecurityWalletDir
+])
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK_FINAL], [
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK_FINAL])
+
+    AC_CONFIG_FILES([
+        src/fty-security-wallet.conf
+    ])
+])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -76,11 +76,3 @@ AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [
     eval socketSecurityWallet=$socketSecurityWallet
     eval socketSecurityWalletDir=$socketSecurityWalletDir
 ])
-
-AC_DEFUN([AX_PROJECT_LOCAL_HOOK_FINAL], [
-    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK_FINAL])
-
-    AC_CONFIG_FILES([
-        src/fty-security-wallet.conf
-    ])
-])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,8 +1,7 @@
 # Customized (manually maintained) bits of configure.ac for fty-warranty
 
-AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
-    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK])
-
+AC_DEFUN([AX_FTY_SECURITY_WALLET_SOCKET_PATH_ARG], [
+    dnl # Reference this routine in AX_PROJECT_LOCAL_HOOK
     dnl # These paths are in sync with definition in fty-security-wallet acinclude.m4
     dnl # TODO: Default to rooting at "runstatedir" and default that to "/run" in packaging
     AC_ARG_WITH([socketSecurityWallet],
@@ -10,7 +9,18 @@ AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
         [with_socketSecurityWallet=/run/fty-security-wallet/secw.socket])
     AC_SUBST([socketSecurityWallet], [$with_socketSecurityWallet])
     AC_SUBST([socketSecurityWalletDir], [`dirname $with_socketSecurityWallet`])
+])
 
+AC_DEFUN([AX_FTY_SECURITY_WALLET_SOCKET_PATH_CONFIGVARS], [
+    dnl # Reference this routine at the end of AX_PROJECT_LOCAL_HOOK_CONFIGVARS
+    eval socketSecurityWallet=$socketSecurityWallet
+    eval socketSecurityWalletDir=$socketSecurityWalletDir
+])
+
+AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
+    AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK])
+
+    AX_FTY_SECURITY_WALLET_SOCKET_PATH_ARG
 ])
 
 AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [
@@ -75,6 +85,5 @@ AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [
     AC_DEFINE_UNQUOTED(PREFIXDIR, "${conftemp}", [Default root path for component])
     AC_SUBST(PREFIXDIR)
 
-    eval socketSecurityWallet=$socketSecurityWallet
-    eval socketSecurityWalletDir=$socketSecurityWalletDir
+    AX_FTY_SECURITY_WALLET_SOCKET_PATH_CONFIGVARS
 ])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -3,6 +3,8 @@
 AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [
     AC_MSG_WARN([Running the PROJECT_LOCAL_HOOK])
 
+    dnl # These paths are in sync with definition in fty-security-wallet acinclude.m4
+    dnl # TODO: Default to rooting at "runstatedir" and default that to "/run" in packaging
     AC_ARG_WITH([socketSecurityWallet],
         [AS_HELP_STRING([--with-socketSecurityWallet=PATH], [Filename of fty-security-wallet service Unix socket])],,
         [with_socketSecurityWallet=/run/fty-security-wallet/secw.socket])

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,10 @@ PKG_PROG_PKG_CONFIG
 # Check endianess of the system
 AC_C_BIGENDIAN
 
+# Optional project-local hook (acinclude.m4, add AC_DEFUN([AX_PROJECT_LOCAL_HOOK], [whatever]) )
+ifdef([AX_PROJECT_LOCAL_HOOK],
+    [AX_PROJECT_LOCAL_HOOK])
+
 # See if cppcheck is in PATH; this variable unblocks the "cppcheck" recipe
 # (note that "make cppcheck.xml" can be used - and perhaps fail - regardless)
 AC_CHECK_PROG([WITH_CPPCHECK], [cppcheck], [true], [false])
@@ -1131,6 +1135,12 @@ int main() {
   )]
 )])
 
+# Optional project-local hook to (re-)define some variables that can be used
+# in your project files generated from .in templates - in your acinclude.m4,
+# add AC_DEFUN([AX_PROJECT_LOCAL_HOOK_CONFIGVARS], [whatever])
+ifdef([AX_PROJECT_LOCAL_HOOK_CONFIGVARS],
+    [AX_PROJECT_LOCAL_HOOK_CONFIGVARS])
+
 # Specify output files
 AC_CONFIG_FILES([Makefile
                  doc/Makefile
@@ -1145,6 +1155,12 @@ AM_COND_IF([WITH_SYSTEMD_UNITS],
     ])],
     [])
 
+
+# Optional project-local hook to put some finishing touches in your configure
+# script, override something compared to zproject-generated code, etc. - in
+# your acinclude.m4, add AC_DEFUN([AX_PROJECT_LOCAL_HOOK_FINAL], [whatever])
+ifdef([AX_PROJECT_LOCAL_HOOK_FINAL],
+    [AX_PROJECT_LOCAL_HOOK_FINAL])
 
 AC_OUTPUT
 

--- a/license.xml
+++ b/license.xml
@@ -4,7 +4,7 @@
 // -->
 <starting_year>2019</starting_year>
 <license>
-Copyright (C) 2014 - 2019 Eaton
+Copyright (C) 2014 - 2020 Eaton
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/certgen_certificate_generator_server.cc
+++ b/src/certgen_certificate_generator_server.cc
@@ -345,6 +345,17 @@ namespace certgen
         CertificateGeneratorConfig certgenConfig;
         certgenSi >>= certgenConfig;
 
+        const StorageConfig &conf = certgenConfig.storageConf();
+        if(conf.storageType() == "secw")
+        {
+            // Note: this is deliberately non-const, so we can setSecwSocketPath()
+            StorageConfigSecwParams *secwParams = dynamic_cast<StorageConfigSecwParams*>(conf.params().get());
+            // For secw connections, use server-configured socket path;
+            // server constructor (and config parser in main() routine)
+            // are responsible for setting it to a valid string value.
+            secwParams->setSecwSocketPath(customSecwSocketPath);
+        }
+
         log_debug("certgenConfig storage config params applied for %s: %s",
             configFilePath.c_str(),
             certgenConfig.storageConf().params()->toString().c_str()

--- a/src/certgen_certificate_generator_server.cc
+++ b/src/certgen_certificate_generator_server.cc
@@ -349,6 +349,8 @@ namespace certgen
 
     static void storeToSecw (const Keys & keyPair, const CertificateX509 & cert, const StorageConfigSecwParams & params)
     {
+        const std::string & SECW_SOCKET_PATH = params.secwSocketPath();
+
         // TODO setup socket sync client
         bool certPresent = isCertPresentSecw(params);
 
@@ -445,6 +447,8 @@ namespace certgen
 
     static std::string loadFromSecw (const StorageConfigSecwParams & params)
     {
+        const std::string & SECW_SOCKET_PATH = params.secwSocketPath();
+
         // TODO setup socket sync client
         bool certPresent = isCertPresentSecw(params);
 
@@ -572,6 +576,8 @@ namespace certgen
 
     static bool isCertPresentSecw(const StorageConfigSecwParams & params)
     {
+        const std::string & SECW_SOCKET_PATH = params.secwSocketPath();
+
         fty::SocketSyncClient client(SECW_SOCKET_PATH);
 
         secw::ProducerAccessor secwAccessor(client);

--- a/src/certgen_certificate_generator_server.cc
+++ b/src/certgen_certificate_generator_server.cc
@@ -325,6 +325,12 @@ namespace certgen
         cxxtools::JsonDeserializer deserializer (configJson);
         deserializer.deserialize (certgenSi);
 
+// Uncomment one or both of these to get the feature
+// of setting a configurable secw socket path string
+#define IMPOSE_SECW_SOCKET_PATH_VIRTUAL_JSON
+#define IMPOSE_SECW_SOCKET_PATH_NONCONST_SETTER
+
+#ifdef IMPOSE_SECW_SOCKET_PATH_VIRTUAL_JSON
 // This is a dirtier of two hacks to impose configurable SECW_SOCKET_PATH
 // rootobj / "storage" / "storage_params" / added "secw_socket_path"
 // fix up where "storage/storage_type" == "secw"
@@ -361,10 +367,13 @@ namespace certgen
             log_warning("%s in %s", e.what(), configFilePath.c_str());
             // Fall through to default handling without overrides beforehand
         }
+#endif // IMPOSE_SECW_SOCKET_PATH_VIRTUAL_JSON
 
         CertificateGeneratorConfig certgenConfig;
         certgenSi >>= certgenConfig;
 
+#ifdef IMPOSE_SECW_SOCKET_PATH_NONCONST_SETTER
+// This is a cleaner-looking of two hacks to impose configurable SECW_SOCKET_PATH
         const StorageConfig &conf = certgenConfig.storageConf();
         if(conf.storageType() == "secw")
         {
@@ -375,6 +384,7 @@ namespace certgen
             // are responsible for setting it to a valid string value.
             secwParams->setSecwSocketPath(customSecwSocketPath);
         }
+#endif // IMPOSE_SECW_SOCKET_PATH_NONCONST_SETTER
 
         log_debug("certgenConfig storage config params applied for %s: %s",
             configFilePath.c_str(),

--- a/src/certgen_certificate_generator_server.cc
+++ b/src/certgen_certificate_generator_server.cc
@@ -345,6 +345,11 @@ namespace certgen
         CertificateGeneratorConfig certgenConfig;
         certgenSi >>= certgenConfig;
 
+        log_debug("certgenConfig storage config params applied for %s: %s",
+            configFilePath.c_str(),
+            certgenConfig.storageConf().params()->toString().c_str()
+        );
+
         return certgenConfig;
     }
 

--- a/src/certgen_certificate_generator_server.h
+++ b/src/certgen_certificate_generator_server.h
@@ -34,18 +34,20 @@ namespace certgen
 
     using FctCommandHandler = std::function<std::vector<std::string> (const std::vector<std::string> &)>;
 
-    static const std::string SECW_SOCKET_PATH = "/run/fty-security-wallet/secw.socket";
+    static const std::string DEFAULT_SECW_SOCKET_PATH = "/run/fty-security-wallet/secw.socket";
 
     class CertificateGeneratorServer final : public fty::SyncServer
     {
         public:
-            explicit CertificateGeneratorServer(const std::string & configPath);
+            explicit CertificateGeneratorServer(const std::string & configPath, const std::string & customSecwSocketPath = "");
             fty::Payload handleRequest(const fty::Sender & sender, const fty::Payload & payload) override;
+            void setSecwSocketPath(const std::string & customSecwSocketPath);
 
         private: // methods
             // List of supported commands with a reference to the handler for this command.
             std::string m_configPath;
-            
+            std::string SECW_SOCKET_PATH;
+
             std::map<Command, FctCommandHandler> m_supportedCommands;
             std::map<std::string, std::tuple<fty::Keys, fty::CsrX509, uint64_t>> m_csrPending; // needed to import an existing certificate correctly 
 

--- a/src/certgen_certificate_generator_server.h
+++ b/src/certgen_certificate_generator_server.h
@@ -34,6 +34,7 @@ namespace certgen
 
     using FctCommandHandler = std::function<std::vector<std::string> (const std::vector<std::string> &)>;
 
+    // hard-coded default, if configs do not specify any other path
     static const std::string DEFAULT_SECW_SOCKET_PATH = "/run/fty-security-wallet/secw.socket";
 
     class CertificateGeneratorServer final : public fty::SyncServer
@@ -41,12 +42,13 @@ namespace certgen
         public:
             explicit CertificateGeneratorServer(const std::string & configPath, const std::string & customSecwSocketPath = "");
             fty::Payload handleRequest(const fty::Sender & sender, const fty::Payload & payload) override;
-            void setSecwSocketPath(const std::string & customSecwSocketPath);
 
         private: // methods
             // List of supported commands with a reference to the handler for this command.
             std::string m_configPath;
+
             std::string SECW_SOCKET_PATH;
+            void setSecwSocketPath(const std::string & customSecwSocketPath);
 
             std::map<Command, FctCommandHandler> m_supportedCommands;
             std::map<std::string, std::tuple<fty::Keys, fty::CsrX509, uint64_t>> m_csrPending; // needed to import an existing certificate correctly 

--- a/src/certgen_storage_config.cc
+++ b/src/certgen_storage_config.cc
@@ -85,7 +85,9 @@ namespace certgen
         si.getMember("secw_document_usages") >>= m_documentUsages;
 
         // helper data for counter-agent connection, not part of cert data
-        si.getMember("secw_socket_path") >>= m_secwSocketPath;
+        if (si.findMember("secw_socket_path")) {
+            si.getMember("secw_socket_path") >>= m_secwSocketPath;
+        }
     }
 
     std::string StorageConfigSecwParams::toString() const

--- a/src/certgen_storage_config.cc
+++ b/src/certgen_storage_config.cc
@@ -83,6 +83,9 @@ namespace certgen
         si.getMember("secw_portfolio") >>= m_portfolio;
         si.getMember("secw_document_name") >>= m_documentName;
         si.getMember("secw_document_usages") >>= m_documentUsages;
+
+        // helper data for counter-agent connection, not part of cert data
+        si.getMember("secw_socket_path") >>= m_secwSocketPath;
     }
 
     std::string StorageConfigSecwParams::toString() const

--- a/src/certgen_storage_config.h
+++ b/src/certgen_storage_config.h
@@ -27,8 +27,8 @@
 #include <memory>
 #include <ostream>
 
-#include "cxxtools/serializationinfo.h"
-#include "cxxtools/jsondeserializer.h"
+#include <cxxtools/serializationinfo.h>
+#include <cxxtools/jsondeserializer.h>
 
 namespace certgen
 {

--- a/src/certgen_storage_config.h
+++ b/src/certgen_storage_config.h
@@ -72,6 +72,7 @@ namespace certgen
         std::string m_portfolio;
         std::string m_documentName;
         std::vector<std::string> m_documentUsages;
+        std::string m_secwSocketPath;
     public:
 
         void load(const cxxtools::SerializationInfo& si) override;
@@ -81,6 +82,12 @@ namespace certgen
         const std::string & portfolio() const { return m_portfolio; }
         const std::string & documentName() const { return m_documentName; }
         const std::vector<std::string> & documentUsages() const { return m_documentUsages; }
+
+        // Helper to connect to counter-agent, not part of cert data itself
+        const std::string & secwSocketPath() const {
+            if (m_secwSocketPath.empty()) { return DEFAULT_SECW_SOCKET_PATH; }
+            return m_secwSocketPath;
+        };
     };
 
     class StorageConfigFileParams : public StorageConfigParams

--- a/src/certgen_storage_config.h
+++ b/src/certgen_storage_config.h
@@ -84,10 +84,9 @@ namespace certgen
         const std::vector<std::string> & documentUsages() const { return m_documentUsages; }
 
         // Helper to connect to counter-agent, not part of cert data itself
-        const std::string & secwSocketPath() const {
-            if (m_secwSocketPath.empty()) { return DEFAULT_SECW_SOCKET_PATH; }
-            return m_secwSocketPath;
-        };
+        const std::string & secwSocketPath() const { return m_secwSocketPath; };
+        // Validity is up to caller, here we only store strings
+        void setSecwSocketPath(const std::string & customSecwSocketPath) { m_secwSocketPath = customSecwSocketPath; }
     };
 
     class StorageConfigFileParams : public StorageConfigParams

--- a/src/fty-certificate-generator-agent.cc
+++ b/src/fty-certificate-generator-agent.cc
@@ -35,7 +35,10 @@ void fty_certificate_generator_agent(zsock_t *pipe, void *args)
     const Arguments & arguments = *static_cast<Arguments*>(args);
 
     //create the server
-    certgen::CertificateGeneratorServer server(arguments.at("CONFIG_PATH"));
+    certgen::CertificateGeneratorServer server(
+                                       arguments.at("CONFIG_PATH"),
+                                       arguments.at("SECW_SOCKET")
+                                    );
 
     //launch the agent
     mlm::MlmBasicMailboxServer agent(  pipe,

--- a/src/fty-certificate-generator.cc
+++ b/src/fty-certificate-generator.cc
@@ -39,7 +39,7 @@ int main (int argc, char *argv [])
 
     // Initialize logging, to console first
     const char *logConfigFile = "";
-    ftylog_setInstance(FTY_CERTGEN_AGENT);
+    ftylog_setInstance(FTY_CERTGEN_AGENT, "");
 
     bool verbose = false;
     int argn;
@@ -98,7 +98,7 @@ int main (int argc, char *argv [])
         paramsCertgen["ENDPOINT"] = config.getEntry("secw-malamute/endpoint", DEFAULT_ENDPOINT);
         paramsCertgen["SECW_SOCKET"] = config.getEntry("secw-socket/socket", "");
 
-        logConfigFile = zconfig_get(cfg, "log/config", "");
+        logConfigFile = config.getEntry("log/config", "").c_str();
     }
 
     //If a log config file is configured, try to load it

--- a/src/fty-certificate-generator.cc
+++ b/src/fty-certificate-generator.cc
@@ -29,24 +29,44 @@
 #include "fty_certificate_generator_classes.h"
 
 #define DEFAULT_ENDPOINT      "ipc://@/malamute"
+#define DEFAULT_CONFIG_PATH   "/usr/share/fty-certificate-generator/"
+#define FTY_CERTGEN_AGENT     "fty-certificate-generator"
 
 int main (int argc, char *argv [])
 {
     using Arguments = std::map<std::string, std::string>;
+    char *config_file = NULL;
+
+    // Initialize logging, to console first
+    const char *logConfigFile = "";
+    ftylog_setInstance(FTY_CERTGEN_AGENT);
+
     bool verbose = false;
     int argn;
+    // Parse command line
     for (argn = 1; argn < argc; argn++) {
+        char *param = NULL;
+        if (argn < argc - 1) param = argv [argn+1];
+
         if (streq (argv [argn], "--help")
         ||  streq (argv [argn], "-h")) {
             puts ("fty-certificate-generator [options] ...");
             puts ("  --verbose / -v         verbose test output");
             puts ("  --help / -h            this information");
+            puts ("  -c|--config            path to config file");
             return 0;
         }
         else
         if (streq (argv [argn], "--verbose")
-        ||  streq (argv [argn], "-v"))
+        ||  streq (argv [argn], "-v")) {
             verbose = true;
+        }
+        else
+        if (streq (argv [argn], "--config")
+        ||  streq (argv [argn], "-c")) {
+            if (param) config_file = param;
+            ++argn;
+        }
         else {
             printf ("Unknown option: %s\n", argv [argn]);
             return 1;
@@ -55,15 +75,45 @@ int main (int argc, char *argv [])
 
     if (verbose)
     {
-        log_info ("fty-certificate-generator - ");
+        log_info ("fty-certificate-generator - initializing");
     }
 
 //  Insert main code here
     Arguments paramsCertgen;
 
-    paramsCertgen["AGENT_NAME"] = "fty-certificate-generator";
-    paramsCertgen["CONFIG_PATH"] = "/usr/share/fty-certificate-generator/";
-    paramsCertgen["ENDPOINT"] = DEFAULT_ENDPOINT;
+    paramsCertgen["AGENT_NAME"] = FTY_CERTGEN_AGENT;
+    paramsCertgen["CONFIG_PATH"] = DEFAULT_CONFIG_PATH; // not the generic config files, but cert-gen specific config
+    paramsCertgen["ENDPOINT"] = DEFAULT_ENDPOINT; // malamute
+    paramsCertgen["SECW_SOCKET"] = ""; // use default
+
+// Parse generic config file, if any
+    if(config_file)
+    {
+        log_debug (SECURITY_WALLET_AGENT ": loading configuration file from '%s' ...", config_file);
+        mlm::ZConfig config(config_file);
+
+        verbose |= (config.getEntry("server/verbose", "false") == "true");
+
+        paramsCertgen["CONFIG_PATH"] = config.getEntry("certgen-storage/config-path", DEFAULT_CONFIG_PATH);
+        paramsCertgen["ENDPOINT"] = config.getEntry("secw-malamute/endpoint", DEFAULT_ENDPOINT);
+        paramsCertgen["SECW_SOCKET"] = config.getEntry("secw-socket/socket", "");
+
+        logConfigFile = zconfig_get(cfg, "log/config", "");
+    }
+
+    //If a log config file is configured, try to load it
+    if (!streq(logConfigFile, ""))
+    {
+      log_debug("Try to load log configuration file : %s", logConfigFile);
+      ftylog_setConfigFile(ftylog_getInstance(), logConfigFile);
+    }
+
+    if (verbose)
+    {
+        ftylog_setVerboseMode(ftylog_getInstance());
+        log_info ("fty-certificate-generator - configuration parsed");
+    }
+
     zactor_t *certgen_server = zactor_new (fty_certificate_generator_agent,  static_cast<void*>(&paramsCertgen));
 
     while (true)

--- a/src/fty-certificate-generator.cfg.in
+++ b/src/fty-certificate-generator.cfg.in
@@ -20,3 +20,4 @@ certgen-storage
 
 log
     config = /etc/fty/ftylog.cfg                    # configuration file for fty-common-logging
+

--- a/src/fty-certificate-generator.cfg.in
+++ b/src/fty-certificate-generator.cfg.in
@@ -16,7 +16,7 @@ secw-socket
     socket = @socketSecurityWallet@ #   Direct socket endpoint
 
 certgen-storage
-    config-path = @datadir@/@PACKAGE@
+    config-path = @DATADIR@/@PACKAGE@
 
 log
     config = /etc/fty/ftylog.cfg                    # configuration file for fty-common-logging

--- a/src/fty-certificate-generator.cfg.in
+++ b/src/fty-certificate-generator.cfg.in
@@ -7,3 +7,16 @@ server
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     verbose = 0         #   Do verbose logging of activity?
+
+secw-malamute
+    endpoint = ipc://@/malamute #   Malamute endpoint
+    address = security-wallet     #   Agent address
+
+secw-socket
+    socket = @socketSecurityWallet@ #   Direct socket endpoint
+
+certgen-storage
+    config-path = @datadir@/@PACKAGE@
+
+log
+    config = /etc/fty/ftylog.cfg                    # configuration file for fty-common-logging

--- a/src/fty-certificate-generator.cfg.in
+++ b/src/fty-certificate-generator.cfg.in
@@ -16,7 +16,7 @@ secw-socket
     socket = @socketSecurityWallet@ #   Direct socket endpoint
 
 certgen-storage
-    config-path = @DATADIR@/@PACKAGE@
+    config-path = @DATADIR@/@PACKAGE@/  # Note: dirname here must end with slash
 
 log
     config = /etc/fty/ftylog.cfg                    # configuration file for fty-common-logging

--- a/src/fty-certificate-generator.service.in
+++ b/src/fty-certificate-generator.service.in
@@ -7,7 +7,7 @@ After=network.target malamute.service fty-envvars.service fty-security-wallet.se
 Requires=network.target malamute.service fty-envvars.service fty-security-wallet.service
 Conflicts=shutdown.target
 PartOf=bios.target
-ConditionPathExists=/usr/share/fty-certificate-generator/
+ConditionPathExists=@datadir@/@PACKAGE@/
 
 # We need the actual unix socket available to communicate with secw, not
 # just the daemon running; otherwise currently we do not retry and abort :(

--- a/src/fty-certificate-generator.service.in
+++ b/src/fty-certificate-generator.service.in
@@ -7,6 +7,8 @@ After=network.target malamute.service fty-envvars.service fty-security-wallet.se
 Requires=network.target malamute.service fty-envvars.service fty-security-wallet.service
 Conflicts=shutdown.target
 PartOf=bios.target
+
+# config-path for certgen
 ConditionPathExists=@datadir@/@PACKAGE@/
 
 # We need the actual unix socket available to communicate with secw, not

--- a/src/fty-certificate-generator.service.in
+++ b/src/fty-certificate-generator.service.in
@@ -9,7 +9,7 @@ Conflicts=shutdown.target
 PartOf=bios.target
 
 # config-path for certgen
-ConditionPathExists=@datadir@/@PACKAGE@/
+ConditionPathExists=@DATADIR@/@PACKAGE@/
 
 # We need the actual unix socket available to communicate with secw, not
 # just the daemon running; otherwise currently we do not retry and abort :(

--- a/src/fty-certificate-generator.service.in
+++ b/src/fty-certificate-generator.service.in
@@ -30,7 +30,7 @@ EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 EnvironmentFile=-/run/fty-envvars.env
-ExecStart=@prefix@/bin/fty-certificate-generator
+ExecStart=@prefix@/bin/fty-certificate-generator -c @sysconfdir@/@PACKAGE@/fty-certificate-generator.cfg
 Restart=always
 
 [Install]

--- a/src/fty-certificate-generator.service.in
+++ b/src/fty-certificate-generator.service.in
@@ -9,6 +9,11 @@ Conflicts=shutdown.target
 PartOf=bios.target
 ConditionPathExists=/usr/share/fty-certificate-generator/
 
+# We need the actual unix socket available to communicate with secw, not
+# just the daemon running; otherwise currently we do not retry and abort :(
+### src/certgen_certificate_generator_server.h:    static const std::string SECW_SOCKET_PATH = "/run/fty-security-wallet/secw.socket";
+ConditionPathExists=@socketSecurityWallet@
+
 [Service]
 Type=simple
 User=certificate-generator-daemon


### PR DESCRIPTION
Sister PR to https://github.com/42ity/fty-security-wallet/pull/49 (and https://github.com/42ity/fty-security-wallet/pull/51 that followed), using similarly defined configure-time definition of default shared socket file path.

This PR also adds actually parsing a config file so the template-defined value would get used (keeping so far the hardcoded strings for defaults).